### PR TITLE
Adds a catalog-info.yaml document for the Radiator project

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -1,0 +1,14 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: jsboot-rails
+  description: |
+    A small solution for removing all inline javascript from your views.
+  annotations:
+    backstage.io/source-location: url:https://github.com/Kajabi/jsboot-rails/tree/master
+    github.com/project-slug: Kajabi/jsboot-rails
+spec:
+  system: kajabi-products
+  type: gem
+  owner: standard-model
+  lifecycle: production


### PR DESCRIPTION
Adds a `catalog-info.yaml` document to register the repository with the [Radiator](https://radiator.staging.kajabi.farm) project. Reach out to @Kajabi/standard-model with questions.